### PR TITLE
:sparkles: Add `reqwest-async` backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 /.idea
-/target
+**/target
 /Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,10 @@ default-features = false
 version = "2.1.0"
 default-features = false
 
+[dev-dependencies.tokio]
+version = "1"
+features = ["rt-multi-thread", "macros"]
+
 [features]
 default = ["ureq", "json"]
 ureq = ["dep:ureq"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ default-features = false
 default = ["ureq", "json"]
 ureq = ["dep:ureq"]
 reqwest-async = ["dep:reqwest", "async-tokio"]
-async-tokio = ["dep:tokio", "tokio/rt"]
+async-tokio = ["tokio", "tokio/rt"]
 json = ["dep:serde_json"]
 structured_logging = ["log/kv_unstable_std"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,16 @@ version = "2.6.2"
 default-features = false
 optional = true
 
+[dependencies.reqwest]
+version = "0.11"
+default-features = false
+optional = true
+
+[dependencies.tokio]
+version = "1"
+default-features = false
+optional = true
+
 [dev-dependencies.fern]
 version = "0.6.2"
 default-features = false
@@ -54,6 +64,8 @@ default-features = false
 [features]
 default = ["ureq", "json"]
 ureq = ["dep:ureq"]
+reqwest-async = ["dep:reqwest", "async-tokio"]
+async-tokio = ["dep:tokio", "tokio/rt"]
 json = ["dep:serde_json"]
 structured_logging = ["log/kv_unstable_std"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ version = "0.21.0"
 default-features = false
 features = ["std"]
 
+[dependencies.parking_lot]
+version = "0.12"
+
 [dependencies.serde_json]
 version = "1.0.96"
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,6 +374,7 @@ impl FenrirBuilder {
     /// # Example
     /// ```
     /// use tokio::runtime::Handle;
+    /// use fenrir_rs::Fenrir;
     ///
     /// # #[tokio::main]
     /// # async fn main() {
@@ -395,11 +396,12 @@ impl FenrirBuilder {
     /// # Example
     /// ```
     /// use tokio::runtime::Handle;
+    /// use fenrir_rs::Fenrir;
     ///
     /// # #[tokio::main]
     /// # async fn main() {
     ///   let builder = Fenrir::builder()
-    ///     .tokio_rt_handle();
+    ///     .tokio_rt_handle_current();
     /// # }
     #[cfg(feature = "async-tokio")]
     pub fn tokio_rt_handle_current(mut self) -> FenrirBuilder {

--- a/src/noop.rs
+++ b/src/noop.rs
@@ -1,13 +1,13 @@
 //! A module which contains the implementation for the [`FenrirBackend`] trait which ignores all
 //! network requests.
-use crate::{AuthenticationMethod, FenrirBackend, SerializationFn, Streams};
+use crate::{AuthenticationMethod, FenrirBackend};
 use std::any::TypeId;
 
 /// The [`NoopBackend`] is used by default and does ignore all logging messages.
 pub(crate) struct NoopBackend;
 
 impl FenrirBackend for NoopBackend {
-    fn send(&self, _: &Streams, _: SerializationFn) -> Result<(), String> {
+    fn send(&self, _: Vec<u8>) -> Result<(), String> {
         Ok(())
     }
 

--- a/src/reqwest.rs
+++ b/src/reqwest.rs
@@ -1,0 +1,84 @@
+//! A module which contains the implementation for the [`FenrirBackend`] trait which uses the `reqwest`
+//! crate for network communication.
+
+use crate::{AuthenticationMethod, FenrirBackend};
+use reqwest::Client;
+use std::any::TypeId;
+use url::Url;
+
+/// A [`FenrirBackend`] implementation which uses the [reqwest](https://crates.io/crates/reqwest) crate to
+/// send logging messages to a Loki endpoint.
+pub(crate) struct ReqwestBackend {
+    /// The loki endpoint which is used to send log information to
+    pub(crate) endpoint: Url,
+    /// The authentication method to use when sending the log messages to the remote [`UreqBackend::endpoint`]
+    pub(crate) authentication: AuthenticationMethod,
+    /// The credentials to use to authenticate against the remote [`UreqBackend::endpoint`]
+    pub(crate) credentials: String,
+    /// Internal client
+    pub(crate) client: Client,
+    /// Runtime handle
+    pub(crate) runtime_handle: tokio::runtime::Handle,
+}
+
+impl FenrirBackend for ReqwestBackend {
+    fn send(&self, serialized_streams: Vec<u8>) -> Result<(), String> {
+        let post_url: Url = self
+            .endpoint
+            .clone()
+            .join("/loki/api/v1/push")
+            .map_err(|e| e.to_string())?;
+        let mut builder = self
+            .client
+            .post(post_url)
+            .header("Content-Type", "application/json; charset=utf-8");
+        if let AuthenticationMethod::Basic = self.authentication {
+            builder = builder.header(
+                "Authorization",
+                format!("Basic {}", self.credentials).as_str(),
+            );
+        }
+        builder = builder.body(serialized_streams);
+        let runtime_handle = self.runtime_handle.clone();
+        runtime_handle.spawn(async move {
+            // retry 3 times if failed with a non-400 error
+            let mut retry_count = 0;
+            loop {
+                let b2 = builder.try_clone().expect("should be able to clone");
+                let res = builder.send().await;
+                match res {
+                    Ok(_) => {
+                        break;
+                    }
+                    Err(e) => {
+                        if e.status().map_or(false, |x| x.is_client_error()) || retry_count >= 3 {
+                            log::error!("Failed to send logs to Loki: {}", e);
+                            break;
+                        }
+                        retry_count += 1;
+                    }
+                }
+                builder = b2;
+            }
+        });
+
+        Ok(())
+    }
+
+    fn internal_type(&self) -> TypeId {
+        use std::any::Any;
+
+        TypeId::of::<Self>().type_id()
+    }
+
+    fn authentication_method(&self) -> AuthenticationMethod {
+        self.authentication.clone()
+    }
+
+    fn credentials(&self) -> Option<String> {
+        if self.credentials.len() > 0 {
+            return Some(self.credentials.clone());
+        }
+        None
+    }
+}


### PR DESCRIPTION
As the title states, this commit adds a `reqwest-async` backend. It requires the `tokio` runtime, as it spawns an async background task.

Currently untested, needed to push to be able to test.

Closes #1 