### PR TITLE
Add support for ProtoBuffers for sending logging information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,11 @@ version = "1.28.2"
 default-features = false
 optional = true
 
+[dependencies.protobuf]
+version = "3.2.0"
+default-features = false
+optional = true
+
 [dev-dependencies.value-bag]
 version = "1.4.1"
 default-features = false
@@ -76,6 +81,7 @@ reqwest-async = ["dep:reqwest", "async-tokio"]
 async-tokio = ["tokio", "tokio/rt"]
 json = ["dep:serde_json"]
 structured_logging = ["log/kv_unstable_std"]
+protobuf = ["dep:protobuf"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Currently the crate only supports logging messages send via JSON to the Loki backend. The recommended way for the best performance however is to use ProtoBuffers for the payload. This PR should implement this as an optional features for the crate.